### PR TITLE
Adding pre-commit config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,41 @@
-offline_deploy/
-.idea/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+_version.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+ansible-env/
+
+# IntelliJ
+.idea
+
+# Project specific
+offline_deploy/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,58 @@
+default_language_version:
+  python: python3
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      # Git style
+      - id: check-added-large-files
+      - id: check-merge-conflict
+        args: [ '--assume-in-merge' ]
+      - id: check-vcs-permalinks
+      - id: forbid-new-submodules
+
+      # Common errors
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: [ '--markdown-linebreak-ext=md' ]
+        exclude: CHANGELOG.md
+      - id: check-yaml
+      - id: check-executables-have-shebangs
+
+      # Cross-platform
+      - id: check-case-conflict
+      - id: mixed-line-ending
+        args: [ '--fix=lf' ]
+
+      # Security
+      - id: detect-aws-credentials
+        args: [ '--allow-missing-credentials' ]
+      - id: detect-private-key
+
+      # Common config formats
+      - id: check-json
+      - id: check-toml
+      - id: check-yaml
+      - id: sort-simple-yaml
+
+  # Shell formatting and check
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: shfmt
+        args: [ '-l', '-i', '2', '-ci', '-sr', '-w' ]
+      - id: shellcheck
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        additional_dependencies: [ "tomli" ]
+
+  - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
+    rev: v2.14.0
+    hooks:
+      - id: pretty-format-toml
+        args: [ --autofix, --no-sort ]
+      - id: pretty-format-yaml
+        args: [ --autofix, --indent, '2', '--offset', '2', --preserve-quotes ]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can configure just one VM by passing --limit <VM-name>
 ansible-playbook -i inventory/hosts.ini playbooks/configure_vms.yml -l panda-worker-node -e @../sites_manifests/panda-dev-versions.yml
 ```
 
-### 3. Get the password for kunernetes dashboard
+### 3. Get the password for Kubernetes Dashboard
 
 1. Configure the VMs
 Once your VMs are created and reachable (ensure they are added to your inventory as needed), run:
@@ -64,3 +64,13 @@ Once your VMs are created and reachable (ensure they are added to your inventory
 ```bash
 kubectl get secret admin-user -n kubernetes-dashboard -o jsonpath="{.data.token}" | base64 -d
 ```
+
+
+
+## Development
+
+### 1. Setting up a development environment
+TBD
+### 2. Testing
+
+#### Running CI


### PR DESCRIPTION
Adding pre-commit config to the repo
Currently - no side affects unless you... run it 😄 

## This PR includes
- `.pre-commit-config.yaml` with a BUNCH of linters selected for this repo
- Basic run instructions in the README.md
- Some improvements to .gitignore - not related, but IMO small enough to bundle in this PR

## This PR does NOT include
- all the changes resulting in running the pre-commit command - since a lot of the hooks format (=FIX linting issues). I did this to not make this PR "scary" and leave the application of the changes to a followup PR and for the repo maintainers (cc @Idanbunimovich @bennykoren @odedaviyam )
- automation / CI

## What comes next?
- This PR needs to be merged
- manually running the command from the repo root:
`pre-commit run --all-files --show-diff-on-failure`
will result in hella-lot-of changes. Those need to be PRd and merged to reach a state were tip-of-main provides a clean run.
- ping @omesser - I'll add a simple github action to run this in CI to establish a linting CI. Failing lint should prevent a PR from being mergable (repo admin can always bypass)
- contiuous - we add/configure/tweek linters and people get used to running it locally before opening any PR.

## What is pre-commit:
Read: https://pre-commit.com/

## Standardize
We standardize on pre-commit on all our new repos!

Examples:
- https://github.com/PrismaPhotonics/py-template/blob/main/%7B%7Bcookiecutter.project_name%7D%7D/.pre-commit-config.yaml
- https://github.com/PrismaPhotonics/pz-core-libs/blob/main/.pre-commit-config.yaml

## note:
You can always NOT register the pre-commit hooks to run automatically on (git) pre-commit, and just run them manually.

